### PR TITLE
Track 0.4-dev updates, explicitly require v0.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.4-
+julia 0.3-

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.3
+julia 0.4-

--- a/src/MatrixMarket.jl
+++ b/src/MatrixMarket.jl
@@ -80,7 +80,9 @@ end
 
 # Hack to represent skew-symmetric matrix as an ordinary matrix with duplicated elements
 function skewsymmetric!(M::AbstractMatrix)
-    for i = 1:size(M,1), j = 1:size(M,2)
+    m,n = size(M)
+    m == n || throw(DimensionMismatch())
+    for i=1:n, j=1:n
         if M[i,j] != 0
             M[j,i] = -M[i,j]
         end
@@ -89,7 +91,9 @@ function skewsymmetric!(M::AbstractMatrix)
 end
 
 function symmetric!(M::AbstractMatrix)
-    for i = 1:size(M,1), j = 1:size(M,2)
+    m,n = size(M)
+    m == n || throw(DimensionMismatch())
+    for i=1:n, j=1:n
         if M[i,j] != 0
             M[j,i] = M[i,j]
         end
@@ -98,7 +102,9 @@ function symmetric!(M::AbstractMatrix)
 end
 
 function hermitian!(M::AbstractMatrix)
-    for i = 1:size(M,1), j = 1:size(M,2)
+    m,n = size(M)
+    m == n || throw(DimensionMismatch())
+    for i=1:n, j=1:n
         if M[i,j] != 0
             M[j,i] = conj(M[i,j])
         end

--- a/src/MatrixMarket.jl
+++ b/src/MatrixMarket.jl
@@ -36,8 +36,8 @@ function mmread(filename, infoonly::Bool=false)
              throw(ParseError("Unsupported field $field (only real and complex are supported)"))
 
     symlabel = symm == "general" ? identity :
-               symm == "symmetric" ? Symmetric :
-               symm == "hermitian" ? Hermitian :
+               symm == "symmetric" ? symmetric! :
+               symm == "hermitian" ? hermitian! :
                symm == "skew-symmetric" ? skewsymmetric! :
                throw(ParseError("Unknown matrix symmetry: $symm (only general, symmetric, skew-symmetric and hermitian are supported)"))
 
@@ -83,6 +83,24 @@ function skewsymmetric!(M::AbstractMatrix)
     for i = 1:size(M,1), j = 1:size(M,2)
         if M[i,j] != 0
             M[j,i] = -M[i,j]
+        end
+    end
+    return M
+end
+
+function symmetric!(M::AbstractMatrix)
+    for i = 1:size(M,1), j = 1:size(M,2)
+        if M[i,j] != 0
+            M[j,i] = M[i,j]
+        end
+    end
+    return M
+end
+
+function hermitian!(M::AbstractMatrix)
+    for i = 1:size(M,1), j = 1:size(M,2)
+        if M[i,j] != 0
+            M[j,i] = conj(M[i,j])
         end
     end
     return M

--- a/src/MatrixMarket.jl
+++ b/src/MatrixMarket.jl
@@ -2,7 +2,7 @@ module MatrixMarket
 
 export mmread
 
-@doc """
+"""
 ### mmread(filename, infoonly::Bool=false)
 
 Read the contents of the Matrix Market file 'filename' into a matrix,
@@ -13,7 +13,7 @@ array storage).
 If infoonly is true (default: false), only information on the size and
 structure is returned from reading the header. The actual data for the
 matrix elements are not parsed.
-"""->
+"""
 function mmread(filename, infoonly::Bool=false)
     mmfile = open(filename,"r")
     # Read first line

--- a/src/MatrixMarket.jl
+++ b/src/MatrixMarket.jl
@@ -1,67 +1,91 @@
 module MatrixMarket
 
-function mmread(filename::String, infoonly::Bool=false)
-#   Reads the contents of the Matrix Market file 'filename' into a matrix,
-#   which will be either sparse or dense, depending on the Matrix Market format
-#   indicated by 'coordinate' (coordinate sparse storage), or 'array' (dense
-#   array storage).
-#
-#   If infoonly is true (default: false), only information on the size and
-#   structure is returned from reading the header. The actual data for the
-#   matrix elements are not parsed.
-    mmfile = open(filename,"r")
+export mmread
 
-    #Read first line
+@doc """
+### mmread(filename, infoonly::Bool=false)
+
+Read the contents of the Matrix Market file 'filename' into a matrix,
+which will be either sparse or dense, depending on the Matrix Market format
+indicated by 'coordinate' (coordinate sparse storage), or 'array' (dense
+array storage).
+
+If infoonly is true (default: false), only information on the size and
+structure is returned from reading the header. The actual data for the
+matrix elements are not parsed.
+"""->
+function mmread(filename, infoonly::Bool=false)
+    mmfile = open(filename,"r")
+    # Read first line
     firstline = chomp(readline(mmfile))
     tokens = split(firstline)
-    length(tokens)==5 || throw(ParseError(string("Not enough words on first line: ", ll)))
-    tokens[1]=="%%MatrixMarket" || throw(ParseError(string("Not a valid MatrixMarket header:", ll)))
+    if length(tokens) != 5
+        throw(ParseError(string("Not enough words on first line: ", ll)))
+    end
+    if tokens[1] != "%%MatrixMarket"
+        throw(ParseError(string("Not a valid MatrixMarket header:", ll)))
+    end
     (head1, rep, field, symm) = map(lowercase, tokens[2:5])
-    head1=="matrix" || throw(ParseError("Unknown MatrixMarket data type: $head1 (only \"matrix\" is supported)"))
-    eltype = field=="real"    ? Float64 :
-             field=="complex" ? Complex128 :
-             field=="pattern" ? Bool :
+    if head1 != "matrix"
+        throw(ParseError("Unknown MatrixMarket data type: $head1 (only \"matrix\" is supported)"))
+    end
+
+    eltype = field == "real" ? Float64 :
+             field == "complex" ? Complex128 :
+             field == "pattern" ? Bool :
              throw(ParseError("Unsupported field $field (only real and complex are supported)"))
-    symlabel = symm=="general" ? identity :
-               symm=="symmetric" ? Symmetric :
-               symm=="hermitian" ? Hermitian :
-               symm=="skew-symmetric" ? skewsymmetric! :
+
+    symlabel = symm == "general" ? identity :
+               symm == "symmetric" ? Symmetric :
+               symm == "hermitian" ? Hermitian :
+               symm == "skew-symmetric" ? skewsymmetric! :
                throw(ParseError("Unknown matrix symmetry: $symm (only general, symmetric, skew-symmetric and hermitian are supported)"))
 
-    #Skip all comments and empty lines
+    # Skip all comments and empty lines
     ll   = readline(mmfile)
-    while length(chomp(ll))==0 || (length(ll) > 0 && ll[1] == '%') ll = readline(mmfile) end
-
-    #Read matrix dimensions (and number of entries) from first non-comment line
-    dd     = int(split(ll))
-    length(dd) >= (rep == "coordinate" ? 3 : 2) || throw(ParseError(string("Could not read in matrix dimensions from line: ", ll)))
-    rows   = dd[1]
-    cols   = dd[2]
-    entries = rep == "coordinate" ? dd[3] : rows * cols
-    if infoonly return rows, cols, entries, rep, field, symm end
+    while length(chomp(ll))==0 || (length(ll) > 0 && ll[1] == '%')
+        ll = readline(mmfile)
+    end
+    # Read matrix dimensions (and number of entries) from first non-comment line
+    dd = map(parseint, split(ll))
+    if length(dd) < (rep == "coordinate" ? 3 : 2)
+        throw(ParseError(string("Could not read in matrix dimensions from line: ", ll)))
+    end
+    rows = dd[1]
+    cols = dd[2]
+    entries = (rep == "coordinate") ? dd[3] : (rows * cols)
+    if infoonly
+        return (rows, cols, entries, rep, field, symm)
+    end
     if rep == "coordinate"
         rr = Array(Int, entries)
         cc = Array(Int, entries)
         xx = Array(eltype, entries)
         for i in 1:entries
             flds = split(readline(mmfile))
-            rr[i] = int(flds[1])
-            cc[i] = int(flds[2])
-            xx[i] = eltype==Complex128 ? Complex128(float64(flds[3]), float64(flds[4])) :
-                    eltype==Float64 ? float64(flds[3]) :
-                    true
+            rr[i] = parseint(flds[1])
+            cc[i] = parsefloat(flds[2])
+            if eltype == Complex128
+                xx[i] = Complex128(parsefloat(flds[3]), parsefloat(flds[4]))
+            elseif eltype == Float64
+                xx[i] = parsefloat(flds[3])
+            else
+                xx[i] = true
+            end
         end
         return symlabel(sparse(rr, cc, xx, rows, cols))
     end
-    symlabel(reshape([float64(readline(mmfile)) for i in 1:entries], (rows,cols)))
+    return symlabel(reshape([parsefloat(readline(mmfile)) for i in 1:entries], (rows,cols)))
 end
 
-#Hack to represent skew-symmetric matrix as an ordinary matrix with duplicated elements
+# Hack to represent skew-symmetric matrix as an ordinary matrix with duplicated elements
 function skewsymmetric!(M::AbstractMatrix)
     for i = 1:size(M,1), j = 1:size(M,2)
-         M[i,j]==0 || (M[j,i] = -M[i,j])
+        if M[i,j] != 0
+            M[j,i] = -M[i,j]
+        end
     end
-    M
+    return M
 end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ include("dl-matrixmarket.jl")
 
 num_errors = 0
 num_pass = 0
+
 for filename in readdir()
     endswith(filename, ".mtx") || continue
     try
@@ -12,14 +13,18 @@ for filename in readdir()
         println(filename, " : ", typeof(A), "  ", size(A))
         num_pass += 1
     catch err
-	println()
-	println()
-	println("PARSE ERROR")
+        println()
+        println()
+        println("PARSE ERROR")
         println(filename, " : ", typeof(err), " : ", :msg in names(err) ? err.msg : "")
-        isa(err, ErrorException) || println(filter(x->x[1]!=symbol("???"), map(x->ccall(:jl_lookup_code_address, Any, (Ptr{Void}, Cint), x, true), catch_backtrace())))
-	println()
-	println()
-	num_errors += 1
+        if !isa(err, ErrorException)
+            println(filter(x->x[1]!=symbol("???"),
+                    map(x->ccall(:jl_lookup_code_address, Any, (Ptr{Void}, Cint), x, true),
+                    catch_backtrace())))
+        end
+        println()
+        println()
+        num_errors += 1
     end
 end
 


### PR DESCRIPTION
After @jiahao's updates this did not work on 0.3 anyways.  Removes deprecation warnings and adds some docs.