### PR TITLE
mmget

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,3 @@
 julia 0.3
+HTTPClient
+Libz

--- a/src/MatrixMarket.jl
+++ b/src/MatrixMarket.jl
@@ -1,6 +1,9 @@
 module MatrixMarket
 
-export mmread
+using HTTPClient
+# using Requests
+using Libz
+export mmread, mmget
 
 """
 ### mmread(filename, infoonly::Bool=false)
@@ -15,15 +18,54 @@ structure is returned from reading the header. The actual data for the
 matrix elements are not parsed.
 """
 function mmread(filename, infoonly::Bool=false)
-    mmfile = open(filename,"r")
+    retval = spzeros(0,0)
+    open(filename,"r") do mmfile
+        retval = _mmio(mmfile, infoonly)
+    end
+    return retval
+end
+
+function mmget(url::AbstractString, infoonly::Bool=false)
+    compress = false
+    tar = false
+    seekto = 0
+    response = get(url)
+    if startswith(url, "ftp://") && (endswith(url,".gz") || endswith(url, ".Z"))
+        compress = true
+    end
+    if endswith(url,".tar") || endswith(url,".tgz") || endswith(url, ".tar.gz")
+        tar = true
+    end
+    ct = get(response.headers,"Content-Type", [])
+    if "application/x-gzip" in ct
+        compress = true
+    end
+    if tar
+        seekto = 512
+    end
+    mmfile = response.body
+    seek(mmfile,0)
+    if compress
+        mmfile = mmfile |> ZlibInflateInputStream
+
+    end
+    if tar
+        readbytes(mmfile, seekto)   # skip the header for http
+    end
+    return _mmio(mmfile, infoonly)
+end
+
+
+# requires an open IO
+function _mmio(mmfile::IO, infoonly::Bool)
     # Read first line
     firstline = chomp(readline(mmfile))
     tokens = split(firstline)
     if length(tokens) != 5
-        throw(ParseError(string("Not enough words on first line: ", ll)))
+        throw(ParseError(string("Not enough words on first line: ", firstline)))
     end
     if tokens[1] != "%%MatrixMarket"
-        throw(ParseError(string("Not a valid MatrixMarket header:", ll)))
+        throw(ParseError(string("Not a valid MatrixMarket header:", firstline)))
     end
     (head1, rep, field, symm) = map(lowercase, tokens[2:5])
     if head1 != "matrix"
@@ -47,7 +89,7 @@ function mmread(filename, infoonly::Bool=false)
         ll = readline(mmfile)
     end
     # Read matrix dimensions (and number of entries) from first non-comment line
-    dd = map(parseint, split(ll))
+    dd = map(x->parse(Int, x), split(ll))
     if length(dd) < (rep == "coordinate" ? 3 : 2)
         throw(ParseError(string("Could not read in matrix dimensions from line: ", ll)))
     end
@@ -63,19 +105,19 @@ function mmread(filename, infoonly::Bool=false)
         xx = Array(eltype, entries)
         for i in 1:entries
             flds = split(readline(mmfile))
-            rr[i] = parseint(flds[1])
-            cc[i] = parsefloat(flds[2])
+            rr[i] = parse(Int, flds[1])
+            cc[i] = parse(Float64, flds[2])
             if eltype == Complex128
-                xx[i] = Complex128(parsefloat(flds[3]), parsefloat(flds[4]))
+                xx[i] = Complex128(parse(Float64, flds[3]), parse(Float64, flds[4]))
             elseif eltype == Float64
-                xx[i] = parsefloat(flds[3])
+                xx[i] = parse(Float64, flds[3])
             else
                 xx[i] = true
             end
         end
         return symlabel(sparse(rr, cc, xx, rows, cols))
     end
-    return symlabel(reshape([parsefloat(readline(mmfile)) for i in 1:entries], (rows,cols)))
+    return symlabel(reshape([parse(Float64, readline(mmfile)) for i in 1:entries], (rows,cols)))
 end
 
 # Hack to represent skew-symmetric matrix as an ordinary matrix with duplicated elements

--- a/test/dl-matrixmarket.jl
+++ b/test/dl-matrixmarket.jl
@@ -49,4 +49,3 @@ for (collectionname, setname, matrixname) in matrixmarketdata[n:n]
         gunzip(gzfname)
     end
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,8 +15,8 @@ for filename in readdir()
     catch err
         println()
         println()
-        println("PARSE ERROR")
-        println(filename, " : ", typeof(err), " : ", :msg in names(err) ? err.msg : "")
+        println("PARSE ERROR - MMREAD")
+        println(filename, " : ", typeof(err), " : ", :msg in fieldnames(err) ? err.msg : "")
         if !isa(err, ErrorException)
             println(filter(x->x[1]!=symbol("???"),
                     map(x->ccall(:jl_lookup_code_address, Any, (Ptr{Void}, Cint), x, true),
@@ -26,6 +26,26 @@ for filename in readdir()
         println()
         num_errors += 1
     end
+end
+
+(collectionname, setname, matrixname) = rand(matrixmarketdata)
+url = "ftp://math.nist.gov/pub/MatrixMarket2/$collectionname/$setname/$matrixname.mtx.gz"
+println("testing mmget on $url")
+try
+    z = mmget(url)
+catch err
+    println()
+    println()
+    println("PARSE ERROR - MMGET")
+    println(url, " : ", typeof(err), " : ", :msg in fieldnames(err) ? err.msg : "")
+    if !isa(err, ErrorException)
+        println(filter(x->x[1]!=symbol("???"),
+                map(x->ccall(:jl_lookup_code_address, Any, (Ptr{Void}, Cint), x, true),
+                catch_backtrace())))
+    end
+    println()
+    println()
+    num_errors += 1
 end
 
 println("Summary: $num_errors parse errors in $(num_errors + num_pass) matrices ")


### PR DESCRIPTION
I created an `mmget()` function that takes a URL and downloads, extracts, interprets, and returns the corresponding matrix. Tests include downloading a random matrix from the same repo as the existing tests.

The file extension testing might be a bit fragile but it's working for all my test cases so far.

I also fixed a couple of bugs in the original code where `ll` was used instead of `firstline` where errors are being thrown, and got rid of the deprecation warnings.