### PR TITLE
Vastly increase the speed of mmread

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.4
+Compat

--- a/src/MatrixMarket.jl
+++ b/src/MatrixMarket.jl
@@ -1,5 +1,7 @@
 module MatrixMarket
 
+import Compat.issymmetric
+
 export mmread, mmwrite
 
 """

--- a/src/MatrixMarket.jl
+++ b/src/MatrixMarket.jl
@@ -96,7 +96,7 @@ function mmread(filename, infoonly::Bool=false)
     return symlabel(reshape([parse(Float64, readline(mmfile)) for i in 1:entries], (rows,cols)))
 end
 
-function find_splits(s :: ASCIIString, num)
+function find_splits(s :: String, num)
     splits = Array(Int, num)
     cur = 1
     in_space = s[1] == '\t' || s[1] == ' '

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,9 +23,9 @@ for filename in readdir()
         println()
         println()
         println("PARSE ERROR")
-        println(filename, " : ", typeof(err), " : ", :msg in names(err) ? err.msg : "")
+        println(filename, " : ", err)
         if !isa(err, ErrorException)
-            println(filter(x->x[1]!=symbol("???"),
+            println(filter(x->x[1]!=Symbol("???"),
                     map(x->ccall(:jl_lookup_code_address, Any, (Ptr{Void}, Cint), x, true),
                     catch_backtrace())))
         end


### PR DESCRIPTION
This patch rewrites mmread to be much faster.

There are two changes:
1. Avoid using split during parsing because it allocates. Instead, search through the current line the start of each number.
2. Avoid directly indexing into a sparse matrix in `skewsymmetric!`, `symmetric!`, `hermitian!`.