### PR TITLE
Bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MatrixMarket"
 uuid = "f617c4c8-c2da-11e8-01e6-abadcf6019ba"
 authors = ["Tristan Konolige <tristan.konolige@gmail.com>"]
-version = "0.2.1"
+version = "0.3.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
Versions 0.2.2 and 0.3.0 were released but the version in Project.toml
was not bumped. Hence it now changes from 0.2.1 to 0.3.1.