### PR TITLE
Avoid invalid combination of 'integer Hermitian'

### DIFF
--- a/src/MatrixMarket.jl
+++ b/src/MatrixMarket.jl
@@ -158,8 +158,8 @@ function mmwrite(filename, matrix :: SparseMatrixCSC)
            eltype(matrix) <: AbstractFloat ? "real" :
            eltype(matrix) <: Complex ? "complex" :
            error("Invalid matrix type")
-      sym = ishermitian(matrix) ? "hermitian" :
-            issymmetric(matrix) ? "symmetric" :
+      sym = issymmetric(matrix) ? "symmetric" :
+            ishermitian(matrix) ? "hermitian" :
             "general"
       symb = issymmetric(matrix)
 


### PR DESCRIPTION
Fixes #33, the `out.mtx` file now has a valid combination of qualifiers:

```
%%MatrixMarket matrix coordinate integer symmetric
2 2 1
2 1 1
```