### PR TITLE
Remove direct TranscodingStreams dep

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,18 +7,16 @@ version = "0.5.1"
 CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [compat]
 CodecZlib = "0.7"
-TranscodingStreams = "0.9, 0.10"
-julia = "1"
-LinearAlgebra = "^1"
-SparseArrays = "^1"
 Downloads = "^1"
-Test = "^1"
-SHA = "0.7, 1"
 GZip = "0.5, 0.6"
+LinearAlgebra = "^1"
+SHA = "0.7, 1"
+SparseArrays = "^1"
+Test = "^1"
+julia = "1"
 
 [extras]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"

--- a/src/MatrixMarket.jl
+++ b/src/MatrixMarket.jl
@@ -3,7 +3,7 @@ module MatrixMarket
 using SparseArrays
 using LinearAlgebra
 
-using TranscodingStreams, CodecZlib
+using CodecZlib
 
 export mmread, mmwrite, mminfo
 

--- a/src/mminfo.jl
+++ b/src/mminfo.jl
@@ -12,7 +12,7 @@ function mminfo(filename::String)
     stream = open(filename, "r")
 
     if endswith(filename, ".gz")
-        stream = TranscodingStream(GzipDecompressor(), stream)
+        stream = GzipDecompressorStream(stream)
     end
 
     info = mminfo(stream)

--- a/src/mmread.jl
+++ b/src/mmread.jl
@@ -17,7 +17,7 @@ function mmread(filename::String, infoonly::Bool=false, retcoord::Bool=false)
     stream = open(filename, "r")
 
     if endswith(filename, ".gz")
-        stream = TranscodingStream(GzipDecompressor(), stream)
+        stream = GzipDecompressorStream(stream)
     end
 
     result = infoonly ? mminfo(stream) : mmread(stream, retcoord)

--- a/src/mmwrite.jl
+++ b/src/mmwrite.jl
@@ -12,7 +12,7 @@ function mmwrite(filename::String, matrix::SparseMatrixCSC)
     stream = open(filename, "w")
 
     if endswith(filename, ".gz")
-        stream = TranscodingStream(GzipCompressor(), stream)
+        stream = GzipCompressorStream(stream)
     end
 
     mmwrite(stream, matrix)


### PR DESCRIPTION
Switching from `TranscodingStream(GzipDecompressor(), stream)` to `GzipDecompressorStream(stream)` allows removing the direct dependence on `TranscodingStreams`.
This allows `TranscodingStreams` to be updated to the latest version.

Currently, this package prevents new versions of `ZipArchives` from being installed, for example https://github.com/JuliaIO/ZipArchives.jl/issues/60