### PR TITLE
Don't change newline on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf

--- a/src/mmwrite.jl
+++ b/src/mmwrite.jl
@@ -20,7 +20,7 @@ function mmwrite(filename::String, matrix::SparseMatrixCSC)
 end
 
 function mmwrite(stream::IO, matrix::SparseMatrixCSC)
-    nl = get_newline()
+    nl = "\n"
     elem = generate_eltype(eltype(matrix))
     sym = generate_symmetric(matrix)
 
@@ -62,20 +62,12 @@ function generate_symmetric(m::AbstractMatrix)
 end
 
 function generate_entity(i, j, rows, vals, kind::String)
-    nl = get_newline()
+    nl = "\n"
     if kind == "pattern"
         return "$(rows[j]) $i$nl"
     elseif kind == "complex"
         return "$(rows[j]) $i $(real(vals[j])) $(imag(vals[j]))$nl"
     else
         return "$(rows[j]) $i $(vals[j])$nl"
-    end
-end
-
-function get_newline()
-    if Sys.iswindows()
-        return "\r\n"
-    else
-        return "\n"
     end
 end

--- a/test/mtx.jl
+++ b/test/mtx.jl
@@ -55,8 +55,7 @@
         mmwrite(newfilename, res)
 
         stream = GzipDecompressorStream(open(gz_filename))
-        adjusted_content = replace(read(stream, String), "\n" => get_newline())
-        sha_test = bytes2hex(sha256(adjusted_content))
+        sha_test = bytes2hex(sha256(read(stream, String)))
         close(stream)
 
         stream = GzipDecompressorStream(open(newfilename))

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,11 +1,3 @@
-function get_newline()
-    if Sys.iswindows()
-        return "\r\n"
-    else
-        return "\n"
-    end
-end
-
 function gunzip(fname)
     destname, ext = splitext(fname)
     if ext != ".gz"


### PR DESCRIPTION
This PR ensures the same bytes are written out on all systems. This is especially useful on Windows when using WSL, where files written in Windows must be read in Linux.

I also added a `.gitattributes` file to prevent GitHub Windows CI from changing the file endings: https://code.visualstudio.com/docs/devcontainers/tips-and-tricks#_resolving-git-line-ending-issues-in-containers-resulting-in-many-modified-files